### PR TITLE
rename rank 0 to "locked"

### DIFF
--- a/projects/app/src/app/(menu)/skills/index.tsx
+++ b/projects/app/src/app/(menu)/skills/index.tsx
@@ -3,8 +3,13 @@ import { getAllTargetHanziWords } from "@/client/query";
 import { HanziWordRefText } from "@/client/ui/HanziWordRefText";
 import type { HanziWord, SrsStateType } from "@/data/model";
 import type { Skill } from "@/data/rizzleSchema";
-import type { RankedHanziWord } from "@/data/skills";
-import { getHanziWordRank, rankRules } from "@/data/skills";
+import type { RankedHanziWord, RankNumber } from "@/data/skills";
+import {
+  coerceRank,
+  getHanziWordRank,
+  rankName,
+  rankRules,
+} from "@/data/skills";
 import { meaningKeyFromHanziWord } from "@/dictionary/dictionary";
 import { sortComparatorNumber } from "@/util/collections";
 import { Text, View } from "react-native";
@@ -102,24 +107,12 @@ const rankLozengeTextClass = tv({
   },
 });
 
-export type RankNumber = 0 | 1 | 2 | 3 | 4;
-
 export function RankLozenge({ rank }: { rank: RankNumber }) {
   return (
     <View className="items-start">
-      <Text className={rankLozengeTextClass({ rank })}>Rank {rank}</Text>
+      <Text className={rankLozengeTextClass({ rank })}>{rankName(rank)}</Text>
     </View>
   );
-}
-
-function coerceRank(rank: number): RankNumber {
-  if (rank < 0) {
-    return 0;
-  }
-  if (rank > 4) {
-    return 4;
-  }
-  return rank as RankNumber;
 }
 
 export function SkillTile({

--- a/projects/app/src/app/dev/ui.tsx
+++ b/projects/app/src/app/dev/ui.tsx
@@ -19,6 +19,7 @@ import { Use } from "@/client/ui/Use";
 import { WikiHanziWordModal } from "@/client/ui/WikiHanziWordModal";
 import { QuestionFlagKind } from "@/data/model";
 import { hanziWordToPinyinQuestionOrThrow } from "@/data/questions/hanziWordToPinyin";
+import type { RankNumber } from "@/data/skills";
 import {
   hanziWordToGloss,
   hanziWordToPinyin,
@@ -35,7 +36,6 @@ import { StrictMode, useCallback, useRef, useState } from "react";
 import { Pressable, ScrollView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { tv } from "tailwind-variants";
-import type { RankNumber } from "../(menu)/skills";
 import { RankLozenge, SkillTile } from "../(menu)/skills";
 
 function DesignSystemPage() {

--- a/projects/app/src/data/skills.ts
+++ b/projects/app/src/data/skills.ts
@@ -916,3 +916,23 @@ export function isStable(srsState: SrsStateType | undefined | null): boolean {
 }
 
 const weekInMillis = 1000 * 60 * 60 * 24 * 7;
+
+export type RankNumber = 0 | 1 | 2 | 3 | 4;
+
+export function rankName(rank: RankNumber): string {
+  if (rank === 0) {
+    return `Locked`;
+  }
+
+  return `Rank ${rank}`;
+}
+
+export function coerceRank(rank: number): RankNumber {
+  if (rank < 0) {
+    return 0;
+  }
+  if (rank > 4) {
+    return 4;
+  }
+  return rank as RankNumber;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Skill ranks are now displayed with user-friendly labels (e.g., "Locked", "Rank 1", etc.) instead of plain numbers.

- **Refactor**
  - Improved consistency in how skill ranks are handled and displayed across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->