### PR TITLE
upgrade typescript

### DIFF
--- a/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch
+++ b/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch
@@ -1,5 +1,5 @@
 diff --git a/lib/lib.dom.d.ts b/lib/lib.dom.d.ts
-index edf900a5de22fd63305f87e32d5974716eda7ddd..5424fbf6e03778151b444b9907f35aab0e773370 100644
+index edf900a5de22fd63305f87e32d5974716eda7ddd..e7d8383eaad81bdad616da0eda85e5f2b2d4709a 100644
 --- a/lib/lib.dom.d.ts
 +++ b/lib/lib.dom.d.ts
 @@ -19901,7 +19901,7 @@ declare var Response: {
@@ -11,10 +11,6 @@ index edf900a5de22fd63305f87e32d5974716eda7ddd..5424fbf6e03778151b444b9907f35aab
      /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Response/redirect_static) */
      redirect(url: string | URL, status?: number): Response;
  };
-diff --git a/lib/lib.dom.d.ts b/lib/lib.dom.d.ts
-index 5424fbf6e03778151b444b9907f35aab0e773370..c9e2130aebc9b06bb94ae9af2bdad743206e12e3 100644
---- a/lib/lib.dom.d.ts
-+++ b/lib/lib.dom.d.ts
 @@ -27145,7 +27145,11 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
       * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/releaseEvents)
       */

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@yarnpkg/types": "^4.0.0",
     "prettier": "^3.4.2",
     "semver": "^7.5.0",
-    "typescript": "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch",
+    "typescript": "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch",
     "yaml": "^2.7.0"
   },
   "engines": {
@@ -52,8 +52,8 @@
     "nanoid@npm:^3.3.6": "patch:nanoid@npm%3A5.1.2#~/.yarn/patches/nanoid-npm-5.1.2-40381f6f88.patch",
     "nanoid@npm:3.3.8": "patch:nanoid@npm%3A5.1.2#~/.yarn/patches/nanoid-npm-5.1.2-40381f6f88.patch",
     "nanoid@npm:^3.3.7": "patch:nanoid@npm%3A5.1.2#~/.yarn/patches/nanoid-npm-5.1.2-40381f6f88.patch",
-    "typescript@npm:~5.5.2": "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch",
-    "typescript@npm:^5.7.3": "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch",
+    "typescript@npm:~5.5.2": "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch",
+    "typescript@npm:^5.7.3": "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch",
     "@expo/cli@npm:0.22.20": "patch:@expo/cli@npm%3A0.22.20#~/.yarn/patches/@expo-cli-npm-0.22.20-0232ba978d.patch",
     "@types/pg@npm:8.6.1": "patch:@types/pg@npm%3A8.11.11#~/.yarn/patches/@types-pg-npm-8.11.11-c5a8a91498.patch",
     "@types/pg@npm:*": "patch:@types/pg@npm%3A8.11.11#~/.yarn/patches/@types-pg-npm-8.11.11-c5a8a91498.patch",

--- a/projects/app/eslint.config.mjs
+++ b/projects/app/eslint.config.mjs
@@ -391,6 +391,8 @@ export default tseslint.config(
     rules: {
       // See https://github.com/typescript-eslint/typescript-eslint/issues/7941
       "no-var": `off`,
+      // `any` is useful in declaration files, so allow it.
+      "@typescript-eslint/no-explicit-any": `off`,
       // Conflicts when augmenting an interface by adding ` extends …` but
       // leaving the body empty.
       "@typescript-eslint/no-empty-object-type": `off`,

--- a/projects/app/package.json
+++ b/projects/app/package.json
@@ -161,7 +161,7 @@
     "resolve-package-path": "^4.0.3",
     "ts-essentials": "^10.0.3",
     "tsx": "^4.15.7",
-    "typescript": "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch",
+    "typescript": "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch",
     "typescript-eslint": "^8.26.0",
     "ucd-full": "^16.0.0",
     "vite": "^7.0.0",

--- a/projects/app/src/types/array-from-async.d.ts
+++ b/projects/app/src/types/array-from-async.d.ts
@@ -8,7 +8,6 @@ declare module "array-from-async" {
   declare const exprt: <T, U>(
     iterableOrArrayLike: AsyncIterable<T> | Iterable<T> | ArrayLike<T>,
     mapFn: (value: Awaited<T>, index: number) => U,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     thisArg?: any,
   ) => Promise<Awaited<U>[]>;
   export = exprt;

--- a/projects/eslint-rules/package.json
+++ b/projects/eslint-rules/package.json
@@ -14,6 +14,6 @@
   "private": true,
   "devDependencies": {
     "@typescript-eslint/parser": "^8.36.0",
-    "typescript": "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch"
+    "typescript": "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch"
   }
 }

--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -12,7 +12,7 @@
     "@types/lodash": "4.17.x",
     "prettier": "^3.4.2",
     "tsx": "^4.15.7",
-    "typescript": "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch"
+    "typescript": "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch"
   },
   "private": true
 }

--- a/projects/static/package.json
+++ b/projects/static/package.json
@@ -6,7 +6,7 @@
     "@types/yargs": "^17 <=17.7.x",
     "prettier": "^3.4.2",
     "ts-node": "^10.9.2",
-    "typescript": "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch",
+    "typescript": "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch",
     "yargs": "^17.7.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,20 +108,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.20.5, @babel/generator@npm:^7.25.0, @babel/generator@npm:^7.25.9, @babel/generator@npm:^7.27.3":
-  version: 7.27.3
-  resolution: "@babel/generator@npm:7.27.3"
-  dependencies:
-    "@babel/parser": "npm:^7.27.3"
-    "@babel/types": "npm:^7.27.3"
-    "@jridgewell/gen-mapping": "npm:^0.3.5"
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jsesc: "npm:^3.0.2"
-  checksum: 10c0/341622e17c61d008fc746b655ab95ef7febb543df8efb4148f57cf06e60ade1abe091ed7d6811df17b064d04d64f69bb7f35ab0654137116d55c54a73145a61a
-  languageName: node
-  linkType: hard
-
-"@babel/generator@npm:^7.28.0":
+"@babel/generator@npm:^7.20.5, @babel/generator@npm:^7.25.0, @babel/generator@npm:^7.25.9, @babel/generator@npm:^7.28.0":
   version: 7.28.0
   resolution: "@babel/generator@npm:7.28.0"
   dependencies:
@@ -357,18 +344,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.25.9, @babel/parser@npm:^7.27.0, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.27.3, @babel/parser@npm:^7.27.4":
-  version: 7.27.4
-  resolution: "@babel/parser@npm:7.27.4"
-  dependencies:
-    "@babel/types": "npm:^7.27.3"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10c0/d1bf17e7508585235e2a76594ba81828e48851877112bb8abbecd7161a31fb66654e993e458ddaedb18a3d5fa31970e5f3feca5ae2900f51e6d8d3d35da70dbf
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.28.0":
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.25.3, @babel/parser@npm:^7.25.9, @babel/parser@npm:^7.27.0, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.0":
   version: 7.28.0
   resolution: "@babel/parser@npm:7.28.0"
   dependencies:
@@ -1169,22 +1145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.23.0, @babel/traverse@npm:^7.25.3, @babel/traverse@npm:^7.25.9, @babel/traverse@npm:^7.27.0, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.27.3":
-  version: 7.27.4
-  resolution: "@babel/traverse@npm:7.27.4"
-  dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.27.3"
-    "@babel/parser": "npm:^7.27.4"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.27.3"
-    debug: "npm:^4.3.1"
-    globals: "npm:^11.1.0"
-  checksum: 10c0/6de8aa2a0637a6ee6d205bf48b9e923928a02415771fdec60085ed754dcdf605e450bb3315c2552fa51c31a4662275b45d5ae4ad527ce55a7db9acebdbbbb8ed
-  languageName: node
-  linkType: hard
-
-"@babel/traverse@npm:^7.28.0":
+"@babel/traverse@npm:^7.23.0, @babel/traverse@npm:^7.25.3, @babel/traverse@npm:^7.25.9, @babel/traverse@npm:^7.27.0, @babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.27.3, @babel/traverse@npm:^7.28.0":
   version: 7.28.0
   resolution: "@babel/traverse@npm:7.28.0"
   dependencies:
@@ -1199,27 +1160,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.23.0, @babel/types@npm:^7.25.2, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.0, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.3.3":
-  version: 7.27.3
-  resolution: "@babel/types@npm:7.27.3"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.27.1"
-  checksum: 10c0/bafdfc98e722a6b91a783b6f24388f478fd775f0c0652e92220e08be2cc33e02d42088542f1953ac5e5ece2ac052172b3dadedf12bec9aae57899e92fb9a9757
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.27.6":
-  version: 7.27.7
-  resolution: "@babel/types@npm:7.27.7"
-  dependencies:
-    "@babel/helper-string-parser": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.27.1"
-  checksum: 10c0/1d1dcb5fa7cfba2b4034a3ab99ba17049bfc4af9e170935575246cdb1cee68b04329a0111506d9ae83fb917c47dbd4394a6db5e32fbd041b7834ffbb17ca086b
-  languageName: node
-  linkType: hard
-
-"@babel/types@npm:^7.28.0":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.23.0, @babel/types@npm:^7.25.2, @babel/types@npm:^7.25.9, @babel/types@npm:^7.26.0, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.27.6, @babel/types@npm:^7.28.0, @babel/types@npm:^7.3.3":
   version: 7.28.0
   resolution: "@babel/types@npm:7.28.0"
   dependencies:
@@ -2666,18 +2607,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.2, @jridgewell/gen-mapping@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "@jridgewell/gen-mapping@npm:0.3.5"
-  dependencies:
-    "@jridgewell/set-array": "npm:^1.2.1"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
-    "@jridgewell/trace-mapping": "npm:^0.3.24"
-  checksum: 10c0/1be4fd4a6b0f41337c4f5fdf4afc3bd19e39c3691924817108b82ffcb9c9e609c273f936932b9fba4b3a298ce2eb06d9bff4eb1cc3bd81c4f4ee1b4917e25feb
-  languageName: node
-  linkType: hard
-
-"@jridgewell/gen-mapping@npm:^0.3.12":
+"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.12, @jridgewell/gen-mapping@npm:^0.3.2, @jridgewell/gen-mapping@npm:^0.3.5":
   version: 0.3.12
   resolution: "@jridgewell/gen-mapping@npm:0.3.12"
   dependencies:
@@ -2691,13 +2621,6 @@ __metadata:
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
-  languageName: node
-  linkType: hard
-
-"@jridgewell/set-array@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@jridgewell/set-array@npm:1.2.1"
-  checksum: 10c0/2a5aa7b4b5c3464c895c802d8ae3f3d2b92fcbe84ad12f8d0bfbb1f5ad006717e7577ee1fd2eac00c088abe486c7adb27976f45d2941ff6b0b92b2c3302c60f4
   languageName: node
   linkType: hard
 
@@ -2728,17 +2651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.9":
-  version: 0.3.25
-  resolution: "@jridgewell/trace-mapping@npm:0.3.25"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:^3.1.0"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
-  checksum: 10c0/3d1ce6ebc69df9682a5a8896b414c6537e428a1d68b02fcc8363b04284a8ca0df04d0ee3013132252ab14f2527bc13bea6526a912ecb5658f0e39fd2860b4df4
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:^0.3.28":
+"@jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.28, @jridgewell/trace-mapping@npm:^0.3.9":
   version: 0.3.29
   resolution: "@jridgewell/trace-mapping@npm:0.3.29"
   dependencies:
@@ -4918,7 +4831,7 @@ __metadata:
     tailwindcss: "npm:^3.4.17"
     ts-essentials: "npm:^10.0.3"
     tsx: "npm:^4.15.7"
-    typescript: "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch"
+    typescript: "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch"
     typescript-eslint: "npm:^8.26.0"
     ucd-full: "npm:^16.0.0"
     usehooks-ts: "npm:^3.1.0"
@@ -4954,7 +4867,7 @@ __metadata:
   dependencies:
     "@typescript-eslint/parser": "npm:^8.36.0"
     eslint: "npm:^9.13.0"
-    typescript: "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch"
+    typescript: "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch"
   languageName: unknown
   linkType: soft
 
@@ -4967,7 +4880,7 @@ __metadata:
     nanoid: "patch:nanoid@npm%3A5.1.2#~/.yarn/patches/nanoid-npm-5.1.2-40381f6f88.patch"
     prettier: "npm:^3.4.2"
     tsx: "npm:^4.15.7"
-    typescript: "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch"
+    typescript: "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch"
   languageName: unknown
   linkType: soft
 
@@ -4979,7 +4892,7 @@ __metadata:
     "@types/yargs": "npm:^17 <=17.7.x"
     prettier: "npm:^3.4.2"
     ts-node: "npm:^10.9.2"
-    typescript: "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch"
+    typescript: "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch"
     yargs: "npm:^17.7.2"
   languageName: unknown
   linkType: soft
@@ -6970,7 +6883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.35.1, @typescript-eslint/tsconfig-utils@npm:^8.35.1":
+"@typescript-eslint/tsconfig-utils@npm:8.35.1":
   version: 8.35.1
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.35.1"
   peerDependencies:
@@ -6979,7 +6892,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.36.0, @typescript-eslint/tsconfig-utils@npm:^8.36.0":
+"@typescript-eslint/tsconfig-utils@npm:8.36.0, @typescript-eslint/tsconfig-utils@npm:^8.35.1, @typescript-eslint/tsconfig-utils@npm:^8.36.0":
   version: 8.36.0
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.36.0"
   peerDependencies:
@@ -7010,14 +6923,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.35.1, @typescript-eslint/types@npm:^8.35.1":
+"@typescript-eslint/types@npm:8.35.1":
   version: 8.35.1
   resolution: "@typescript-eslint/types@npm:8.35.1"
   checksum: 10c0/136dd1c7a39685baa398406423a97a4b6a66e6aed7cbd6ae698a89b0fde92c76f1415294bec612791d67d7917fda280caa65b9d761e2744e8143506d1f417fb2
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.36.0, @typescript-eslint/types@npm:^8.36.0":
+"@typescript-eslint/types@npm:8.36.0, @typescript-eslint/types@npm:^8.35.1, @typescript-eslint/types@npm:^8.36.0":
   version: 8.36.0
   resolution: "@typescript-eslint/types@npm:8.36.0"
   checksum: 10c0/cacb941a0caad6ab556c416051b97ec33b364b7c8e0703e2729ae43f12daf02b42eef12011705329107752e3f1685ca82cfffe181d637f85907293cb634bee31
@@ -15210,7 +15123,7 @@ __metadata:
     "@yarnpkg/types": "npm:^4.0.0"
     prettier: "npm:^3.4.2"
     semver: "npm:^7.5.0"
-    typescript: "patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch"
+    typescript: "patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch"
     yaml: "npm:^2.7.0"
   languageName: unknown
   linkType: soft
@@ -18282,33 +18195,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.8.2":
-  version: 5.8.2
-  resolution: "typescript@npm:5.8.2"
+"typescript@npm:5.8.3":
+  version: 5.8.3
+  resolution: "typescript@npm:5.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/5c4f6fbf1c6389b6928fe7b8fcd5dc73bb2d58cd4e3883f1d774ed5bd83b151cbac6b7ecf11723de56d4676daeba8713894b1e9af56174f2f9780ae7848ec3c6
+  checksum: 10c0/5f8bb01196e542e64d44db3d16ee0e4063ce4f3e3966df6005f2588e86d91c03e1fb131c2581baf0fb65ee79669eea6e161cd448178986587e9f6844446dbb48
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch":
-  version: 5.8.2
-  resolution: "typescript@patch:typescript@npm%3A5.8.2#~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch::version=5.8.2&hash=b22165"
+"typescript@patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@npm%3A5.8.3#~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch::version=5.8.3&hash=d04b42"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/7b45af05ca0b995c0f982eff17c5d927ba170e19137c3a925f7e52283e8f9307ecc539621b8086ce224487770363aa94f4c341b258966519fedbf6117123907d
+  checksum: 10c0/0c23ecba682b6a6a2bba630535fceadccff509a9a2ce4901aa2ad8f70a743a456c1adebb63b91cfb9655c2e6b7f7b744f3a33aac4ea5278769291756cc5b386c
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@patch%3Atypescript@npm%253A5.8.2%23~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch#optional!builtin<compat/typescript>":
-  version: 5.8.2
-  resolution: "typescript@patch:typescript@patch%3Atypescript@npm%253A5.8.2%23~/.yarn/patches/typescript-npm-5.8.2-b95d637f6a.patch%3A%3Aversion=5.8.2&hash=b22165#optional!builtin<compat/typescript>::version=5.8.2&hash=5786d5"
+"typescript@patch:typescript@patch%3Atypescript@npm%253A5.8.3%23~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch#optional!builtin<compat/typescript>":
+  version: 5.8.3
+  resolution: "typescript@patch:typescript@patch%3Atypescript@npm%253A5.8.3%23~/.yarn/patches/typescript-npm-5.8.3-fbd7aef456.patch%3A%3Aversion=5.8.3&hash=d04b42#optional!builtin<compat/typescript>::version=5.8.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/558992053bbec8218a7e23cda0b8b8b1aa085c7b9e0ea99600fa75274e73b3d0782893eff570e3e86db07d0498f97ee25dcb4d3d12e020c386ccbc179f7f4020
+  checksum: 10c0/b30f1e1e0436751a4c34d1114f961d78a41d8152cceaeda2af1211861511ea72732fcd80ffaf64339e9b863326ce56da3c25d283de6d8c595816e0ad81763ed6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript dependency to version 5.8.3 across all relevant packages.
  * Updated corresponding patch file references for the new TypeScript version.

* **Style**
  * Adjusted ESLint configuration to allow the use of the `any` type in TypeScript declaration files.
  * Removed an unnecessary ESLint rule comment in a type declaration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->