### PR TITLE
Use a more stable concurrency group for PRs

### DIFF
--- a/.github/instructions/app.instructions.md
+++ b/.github/instructions/app.instructions.md
@@ -12,9 +12,8 @@ The following commands should be used to test the code:
   - Update snapshots: `moon run app:test -- -u`
 
 - Lint uses eslint, so any eslint arguments can be passed after `--`:
-  - Run all lint: `moon run app:lint`
+  - Run all lint (and fix): `moon run app:lint`
   - Run file lint: `moon run app:lint -- <filename>`
-  - Auto-fix lint: `moon run app:lint -- --fix`
 
 - Prettier: `moon run app:prettierCheck`
   - Fix prettier: `moon run app:prettier`

--- a/.github/instructions/eslint-rules.instructions.md
+++ b/.github/instructions/eslint-rules.instructions.md
@@ -12,9 +12,8 @@ The following commands should be used to test the code:
   - Update snapshots: `moon run eslint-rules:test -- -u`
 
 - Lint uses eslint, so any eslint arguments can be passed after `--`:
-  - Run all lint: `moon run eslint-rules:lint`
+  - Run all lint (and fix): `moon run eslint-rules:lint`
   - Run file lint: `moon run eslint-rules:lint -- <filename>`
-  - Auto-fix lint: `moon run eslint-rules:lint -- --fix`
 
 - Prettier: `moon run eslint-rules:prettierCheck`
   - Fix prettier: `moon run eslint-rules:prettier`

--- a/.github/instructions/expo-audio-sprites.instructions.md
+++ b/.github/instructions/expo-audio-sprites.instructions.md
@@ -12,9 +12,8 @@ The following commands should be used to test the code:
   - Update snapshots: `moon run expo-audio-sprites:test -- -u`
 
 - Lint uses eslint, so any eslint arguments can be passed after `--`:
-  - Run all lint: `moon run expo-audio-sprites:lint`
+  - Run all lint (and fix): `moon run expo-audio-sprites:lint`
   - Run file lint: `moon run expo-audio-sprites:lint -- <filename>`
-  - Auto-fix lint: `moon run expo-audio-sprites:lint -- --fix`
 
 - Prettier: `moon run expo-audio-sprites:prettierCheck`
   - Fix prettier: `moon run expo-audio-sprites:prettier`

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.moon/tasks/tag-eslint.yml
+++ b/.moon/tasks/tag-eslint.yml
@@ -1,11 +1,14 @@
 tasks:
   lint:
-    command: eslint . --cache
+    description: "Run ESLint and fix errors (unless in CI)."
+    # Auto-fixing errors outside CI is intended to make this more AI-agent friendly.
+    script: eslint . --cache${CI+"=false"} --fix${CI+"=false"}
     inputs:
       # Config files anywhere within the project
       - "**/*.{cjs,js,mjs,json,ts,tsx}"
       - "*.{cjs,js,mjs,json,ts,tsx}"
       # Environment variables
+      - "$CI"
       - "$ESLINT_CACHE"
       - "$ESLINT_*"
     deps:


### PR DESCRIPTION
Previously using `github.ref` I think created different groups for "approve to run workflows" and "ready for review" events, which meant that if you press Approve workflows and then press Ready for review, it would queue a second PR workflow and wouldn't cancel the first one and you'd have to wait for it to finish.