### PR TITLE
Turn off Git core.quotepath for copilot agent

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -37,3 +37,8 @@ jobs:
         run: |
           cp ./.github/copilot-precommit.sh .git/hooks/pre-commit
           chmod +x .git/hooks/pre-commit
+
+      - name: Git config
+        # core.quotepath tells Git whether to quote “unsafe” characters in paths using C-style escapes (\344\271\237).
+        # Setting it to false disables that quoting, so Git prints raw UTF-8.
+        run: git config core.quotepath false


### PR DESCRIPTION
I'm hoping this improves the LLM's reasoning about errors